### PR TITLE
CON-3016 add timestamp to published message, if empty

### DIFF
--- a/client.go
+++ b/client.go
@@ -395,6 +395,10 @@ MAIN:
 
 			publishing := w.work(*m)
 
+			if publishing.Timestamp.IsZero() {
+				publishing.Timestamp = time.Now()
+			}
+
 			// There are multiple possible failure scenarios that
 			// result in either message Duplication or Loss.
 			if err := c.publish(publishing, w.channel); err != nil {


### PR DESCRIPTION
it allows to track when the message was originated