### PR TITLE
Log message bodies as DEBUG

### DIFF
--- a/client.go
+++ b/client.go
@@ -327,7 +327,7 @@ func (c *Client) receiver(w *worker, log *zerolog.Logger) error {
 		for m := range msgs {
 			func() {
 				logMessage := logCorrelationID(log, m.CorrelationId)
-				logMessage.Info().Func(c.logDelivery(&m)).Msg("consuming job")
+				logMessage.Debug().Func(c.logDelivery(&m)).Msg("consuming job")
 
 				defer func() {
 					if r := recover(); r != nil {


### PR DESCRIPTION
I think the message bodies make too much noise and is out of control of library client.